### PR TITLE
Implement template class generation feature

### DIFF
--- a/CommandForgeGenerator/CodeGenerate/TemplateClassGenerator.cs
+++ b/CommandForgeGenerator/CodeGenerate/TemplateClassGenerator.cs
@@ -1,0 +1,31 @@
+using System.IO;
+using CommandForgeGenerator.Generator.Semantic;
+
+namespace CommandForgeGenerator.Generator.CodeGenerate;
+
+public static class TemplateClassGenerator
+{
+    public static void Generate(string baseDirectory, CommandsSemantics semantics)
+    {
+        if (string.IsNullOrEmpty(semantics.GenerateCodePath)) return;
+
+        var outputDir = Path.Combine(baseDirectory, semantics.GenerateCodePath);
+        Directory.CreateDirectory(outputDir);
+
+        foreach (var command in semantics.Commands)
+        {
+            var filePath = Path.Combine(outputDir, command.ClassName + ".cs");
+            if (File.Exists(filePath)) continue;
+            var code = $$"""
+namespace CommandForgeGenerator.Command
+{{
+    public partial class {command.ClassName}
+    {{
+    }}
+}}
+""";
+            File.WriteAllText(filePath, code);
+        }
+    }
+}
+

--- a/CommandForgeGenerator/CommandForgeGenerator.cs
+++ b/CommandForgeGenerator/CommandForgeGenerator.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Immutable;
+using System.IO;
 using CommandForgeGenerator.Generator.CodeGenerate;
 using CommandForgeGenerator.Generator.Semantic;
 using Microsoft.CodeAnalysis;
@@ -22,6 +23,8 @@ public class CommandForgeGeneratorSourceGenerator : IIncrementalGenerator
         {
             var commandsSchema = CommandSemanticsLoader.GetCommandSemantics(input.additionalTexts);
             var codeFiles = CodeGenerator.Generate(commandsSchema);
+            var yamlDir = Path.GetDirectoryName(input.additionalTexts[0].Path)!;
+            TemplateClassGenerator.Generate(yamlDir, commandsSchema);
             
             if (codeFiles.Count == 0) return;
             

--- a/CommandForgeGenerator/Semantic/CommandSemanticsLoader.cs
+++ b/CommandForgeGenerator/Semantic/CommandSemanticsLoader.cs
@@ -47,7 +47,8 @@ public class CommandSemanticsLoader
         CommandsSemantics ParseCommandsSchema(JsonObject root)
         {
             var commandsJson = root["commands"] as JsonArray ?? throw new Exception("commands 配列が見つかりません。");
-            
+            var generateCodePath = (root["generateCodePath"] as JsonString)?.Literal;
+
             var commands = new List<CommandSemantics>();
             
             foreach (var commandsJsonNode in commandsJson.Nodes)
@@ -96,7 +97,7 @@ public class CommandSemanticsLoader
                 commands.Add(new CommandSemantics(commandName, properties));
             }
             
-            return new CommandsSemantics(commands);
+            return new CommandsSemantics(commands, generateCodePath);
         }
         
         #endregion

--- a/CommandForgeGenerator/Semantic/CommandsSemantics.cs
+++ b/CommandForgeGenerator/Semantic/CommandsSemantics.cs
@@ -5,10 +5,12 @@ namespace CommandForgeGenerator.Generator.Semantic;
 public class CommandsSemantics
 {
     public readonly List<CommandSemantics> Commands;
+    public readonly string? GenerateCodePath;
 
-    public CommandsSemantics(List<CommandSemantics> commands)
+    public CommandsSemantics(List<CommandSemantics> commands, string? generateCodePath = null)
     {
         Commands = commands;
+        GenerateCodePath = generateCodePath;
     }
 }
 


### PR DESCRIPTION
## Summary
- add TemplateClassGenerator to create class skeletons
- store optional `GenerateCodePath` from commands.yaml
- parse `generateCodePath` in `CommandSemanticsLoader`
- invoke template generation from the source generator

## Testing
- `dotnet` not installed, so no tests were run