### PR TITLE
Set language version to C#9

### DIFF
--- a/CommandForgeGenerator.SandBox/CommandForgeGenerator.SandBox.csproj
+++ b/CommandForgeGenerator.SandBox/CommandForgeGenerator.SandBox.csproj
@@ -5,6 +5,7 @@
         <TargetFramework>net8.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
+        <LangVersion>9.0</LangVersion>
         <DefineConstants>ENABLE_COMMAND_FORGE_GENERATOR</DefineConstants>
     </PropertyGroup>
 

--- a/CommandForgeGenerator.SandBox/Program.cs
+++ b/CommandForgeGenerator.SandBox/Program.cs
@@ -3,7 +3,8 @@ using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using UnityEngine.Assertions;
 
-namespace CommandForgeGenerator.SandBox;
+namespace CommandForgeGenerator.SandBox
+{
 
 internal static class Program
 {
@@ -29,4 +30,6 @@ internal static class Program
         var json = File.ReadAllText(skitPath);
         return (JToken)JsonConvert.DeserializeObject(json);
     }
+}
+
 }

--- a/CommandForgeGenerator.Tests/CommandForgeGenerator.Tests.csproj
+++ b/CommandForgeGenerator.Tests/CommandForgeGenerator.Tests.csproj
@@ -3,6 +3,7 @@
     <PropertyGroup>
         <TargetFramework>net8.0</TargetFramework>
         <Nullable>enable</Nullable>
+        <LangVersion>9.0</LangVersion>
 
         <IsPackable>false</IsPackable>
 

--- a/CommandForgeGenerator.Tests/Test.cs
+++ b/CommandForgeGenerator.Tests/Test.cs
@@ -5,7 +5,8 @@ using CommandForgeGenerator.Generator.Semantic;
 using UnityEngine;
 using Xunit;
 
-namespace CommandForgeGenerator.Tests;
+namespace CommandForgeGenerator.Tests
+{
 
 public class Test
 {
@@ -239,4 +240,6 @@ public class Test
         #endregion
 
     }
+}
+
 }

--- a/CommandForgeGenerator/CodeGenerate/CodeGenerator.cs
+++ b/CommandForgeGenerator/CodeGenerate/CodeGenerator.cs
@@ -3,7 +3,8 @@ using System.Collections.Generic;
 using System.Text;
 using CommandForgeGenerator.Generator.Semantic;
 
-namespace CommandForgeGenerator.Generator.CodeGenerate;
+namespace CommandForgeGenerator.Generator.CodeGenerate
+{
 
 public record CodeFile(string FileName, string Code)
 {
@@ -260,4 +261,5 @@ public static class CodeGenerator
         
         return switchCases.ToString();
     }
+}
 }

--- a/CommandForgeGenerator/CommandForgeGenerator.cs
+++ b/CommandForgeGenerator/CommandForgeGenerator.cs
@@ -4,7 +4,8 @@ using CommandForgeGenerator.Generator.CodeGenerate;
 using CommandForgeGenerator.Generator.Semantic;
 using Microsoft.CodeAnalysis;
 
-namespace CommandForgeGenerator.Generator;
+namespace CommandForgeGenerator.Generator
+{
 
 [Generator(LanguageNames.CSharp)]
 public class CommandForgeGeneratorSourceGenerator : IIncrementalGenerator
@@ -46,4 +47,6 @@ public class CommandForgeGeneratorSourceGenerator : IIncrementalGenerator
                   }
                   """;
     }
+}
+
 }

--- a/CommandForgeGenerator/CommandForgeGenerator.csproj
+++ b/CommandForgeGenerator/CommandForgeGenerator.csproj
@@ -4,7 +4,7 @@
         <TargetFramework>netstandard2.0</TargetFramework>
         <IsPackable>true</IsPackable>
         <Nullable>enable</Nullable>
-        <LangVersion>latest</LangVersion>
+        <LangVersion>9.0</LangVersion>
 
         <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
         <IsRoslynComponent>true</IsRoslynComponent>

--- a/CommandForgeGenerator/Json/JsonParser.cs
+++ b/CommandForgeGenerator/Json/JsonParser.cs
@@ -1,7 +1,8 @@
 using System;
 using System.Collections.Generic;
 
-namespace CommandForgeGenerator.Generator.Json;
+namespace CommandForgeGenerator.Generator.Json
+{
 
 public interface IJsonNode
 {
@@ -169,4 +170,6 @@ public static class JsonParser
         public Token CurrentToken => tokens.Length > CurrentIndex ? tokens[CurrentIndex] : new Token(TokenType.Illegal, "");
         public Token NextToken => tokens.Length > CurrentIndex + 1 ? tokens[CurrentIndex + 1] : new Token(TokenType.Illegal, "");
     }
+}
+
 }

--- a/CommandForgeGenerator/Json/JsonTokenizer.cs
+++ b/CommandForgeGenerator/Json/JsonTokenizer.cs
@@ -2,9 +2,26 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 
-namespace CommandForgeGenerator.Generator.Json;
+namespace CommandForgeGenerator.Generator.Json
+{
 
-public record struct Token(TokenType Type, string Literal);
+public readonly struct Token
+{
+    public TokenType Type { get; }
+    public string Literal { get; }
+
+    public Token(TokenType type, string literal)
+    {
+        Type = type;
+        Literal = literal;
+    }
+
+    public void Deconstruct(out TokenType type, out string literal)
+    {
+        type = Type;
+        literal = Literal;
+    }
+}
 
 public enum TokenType
 {
@@ -142,4 +159,6 @@ public static class JsonTokenizer
         public char CurrentChar => sourceText.Length > CurrentIndex ? sourceText[CurrentIndex] : '\0';
         public char NextChar => sourceText.Length > CurrentIndex + 1 ? sourceText[CurrentIndex + 1] : '\0';
     }
+}
+
 }

--- a/CommandForgeGenerator/Json/Yaml.cs
+++ b/CommandForgeGenerator/Json/Yaml.cs
@@ -1,6 +1,7 @@
 using YamlDotNet.Serialization;
 
-namespace CommandForgeGenerator.Generator.Json;
+namespace CommandForgeGenerator.Generator.Json
+{
 
 public static class Yaml
 {
@@ -12,4 +13,6 @@ public static class Yaml
         
         return serializer.Serialize(yamlObject).Trim();
     }
+}
+
 }

--- a/CommandForgeGenerator/Semantic/CommandSemanticsLoader.cs
+++ b/CommandForgeGenerator/Semantic/CommandSemanticsLoader.cs
@@ -4,7 +4,8 @@ using System.Collections.Immutable;
 using CommandForgeGenerator.Generator.Json;
 using Microsoft.CodeAnalysis;
 
-namespace CommandForgeGenerator.Generator.Semantic;
+namespace CommandForgeGenerator.Generator.Semantic
+{
 
 public class CommandSemanticsLoader
 {
@@ -103,3 +104,5 @@ public class CommandSemanticsLoader
     }
 }
 
+
+}

--- a/CommandForgeGenerator/Semantic/CommandsSemantics.cs
+++ b/CommandForgeGenerator/Semantic/CommandsSemantics.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 
-namespace CommandForgeGenerator.Generator.Semantic;
+namespace CommandForgeGenerator.Generator.Semantic
+{
 
 public class CommandsSemantics
 {
@@ -50,4 +51,5 @@ public enum CommandPropertyType{
     Vector4,
     Vector2Int,
     Vector3Int,
+}
 }

--- a/CommandForgeGenerator/Semantic/ReservedCommandSemantics.cs
+++ b/CommandForgeGenerator/Semantic/ReservedCommandSemantics.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 
-namespace CommandForgeGenerator.Generator.Semantic;
+namespace CommandForgeGenerator.Generator.Semantic
+{
 
 public static class ReservedCommandSemantics
 {
@@ -14,4 +15,5 @@ public static class ReservedCommandSemantics
         var groupEnd = new CommandSemantics("group_end", new List<CommandProperty>());
         return new List<CommandSemantics>(){groupStart, groupEnd};
     }
+}
 }

--- a/CommandForgeGenerator/StringExtension.cs
+++ b/CommandForgeGenerator/StringExtension.cs
@@ -1,4 +1,5 @@
-namespace CommandForgeGenerator.Generator;
+namespace CommandForgeGenerator.Generator
+{
 
 public static class StringExtension
 {
@@ -28,4 +29,5 @@ public static class StringExtension
         _array[no] = up;
         return new string(_array);
     }
+}
 }

--- a/CommandForgeGenerator/YamlDotNet/Core/Emitter.cs
+++ b/CommandForgeGenerator/YamlDotNet/Core/Emitter.cs
@@ -56,7 +56,7 @@ namespace YamlDotNet.Core
         private readonly Stack<EmitterState> states = new Stack<EmitterState>();
         private readonly Queue<ParsingEvent> events = new Queue<ParsingEvent>();
         private readonly Stack<int> indents = new Stack<int>();
-        private readonly TagDirectiveCollection tagDirectives = [];
+        private readonly TagDirectiveCollection tagDirectives = new TagDirectiveCollection();
         private int indent;
         private int flowLevel;
         private bool isMappingContext;

--- a/CommandForgeGenerator/YamlDotNet/Core/EmitterSettings.cs
+++ b/CommandForgeGenerator/YamlDotNet/Core/EmitterSettings.cs
@@ -21,7 +21,8 @@
 
 using System;
 
-namespace YamlDotNet.Core;
+namespace YamlDotNet.Core
+{
 
 public sealed class EmitterSettings
 {
@@ -208,4 +209,6 @@ public sealed class EmitterSettings
             true
         );
     }
+}
+
 }

--- a/CommandForgeGenerator/YamlDotNet/Core/MergingParser.cs
+++ b/CommandForgeGenerator/YamlDotNet/Core/MergingParser.cs
@@ -173,9 +173,9 @@ namespace YamlDotNet.Core
 
             public ParsingEventCollection()
             {
-                events = [];
-                deleted = [];
-                references = [];
+                events = new LinkedList<ParsingEvent>();
+                deleted = new HashSet<LinkedListNode<ParsingEvent>>();
+                references = new Dictionary<AnchorName, LinkedListNode<ParsingEvent>>();
             }
 
             public void AddAfter(LinkedListNode<ParsingEvent> node, IEnumerable<ParsingEvent> items)

--- a/CommandForgeGenerator/YamlDotNet/Core/ObjectPool/DefaultObjectPool.cs
+++ b/CommandForgeGenerator/YamlDotNet/Core/ObjectPool/DefaultObjectPool.cs
@@ -28,7 +28,8 @@ using System;
 using System.Collections.Concurrent;
 using System.Threading;
 
-namespace YamlDotNet.Core.ObjectPool;
+namespace YamlDotNet.Core.ObjectPool
+{
 
 /// <summary>
 ///     Default implementation of <see cref="ObjectPool{T}" />.
@@ -122,4 +123,6 @@ internal class DefaultObjectPool<T> : ObjectPool<T> where T : class
 
         return true;
     }
+}
+
 }

--- a/CommandForgeGenerator/YamlDotNet/Core/Parser.cs
+++ b/CommandForgeGenerator/YamlDotNet/Core/Parser.cs
@@ -36,7 +36,7 @@ namespace YamlDotNet.Core
     public class Parser : IParser
     {
         private readonly Stack<ParserState> states = new Stack<ParserState>();
-        private readonly TagDirectiveCollection tagDirectives = [];
+        private readonly TagDirectiveCollection tagDirectives = new TagDirectiveCollection();
         private ParserState state;
 
         private readonly IScanner scanner;

--- a/CommandForgeGenerator/YamlDotNet/Core/ParserExtensions.cs
+++ b/CommandForgeGenerator/YamlDotNet/Core/ParserExtensions.cs
@@ -23,7 +23,8 @@ using System;
 using System.IO;
 using YamlDotNet.Core.Events;
 
-namespace YamlDotNet.Core;
+namespace YamlDotNet.Core
+{
 
 /// <summary>
 ///     Extension methods that provide useful abstractions over <see cref="IParser" />.
@@ -197,4 +198,6 @@ public static class ParserExtensions
         value = null;
         return false;
     }
+}
+
 }

--- a/CommandForgeGenerator/YamlDotNet/Core/Scanner.cs
+++ b/CommandForgeGenerator/YamlDotNet/Core/Scanner.cs
@@ -2518,7 +2518,7 @@ namespace YamlDotNet.Core
             return result;
         }
 
-        private static readonly byte[] EmptyBytes = [];
+        private static readonly byte[] EmptyBytes = Array.Empty<byte>();
 
         /// <summary>
         /// Decode an URI-escape sequence corresponding to a single UTF-8 character.

--- a/CommandForgeGenerator/YamlDotNet/Helpers/ExpressionExtensions.cs
+++ b/CommandForgeGenerator/YamlDotNet/Helpers/ExpressionExtensions.cs
@@ -23,7 +23,8 @@ using System;
 using System.Linq.Expressions;
 using System.Reflection;
 
-namespace YamlDotNet.Helpers;
+namespace YamlDotNet.Helpers
+{
 
 public static class ExpressionExtensions
 {
@@ -65,4 +66,6 @@ public static class ExpressionExtensions
 
         return null;
     }
+}
+
 }

--- a/CommandForgeGenerator/YamlDotNet/Helpers/OrderedDictionary.cs
+++ b/CommandForgeGenerator/YamlDotNet/Helpers/OrderedDictionary.cs
@@ -26,7 +26,8 @@ using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Runtime.Serialization;
 
-namespace YamlDotNet.Helpers;
+namespace YamlDotNet.Helpers
+{
 
 [Serializable]
 internal sealed class OrderedDictionary<TKey, TValue> : IOrderedDictionary<TKey, TValue>
@@ -43,7 +44,7 @@ internal sealed class OrderedDictionary<TKey, TValue> : IOrderedDictionary<TKey,
 
     public OrderedDictionary(IEqualityComparer<TKey> comparer)
     {
-        list = [];
+        list = new List<KeyValuePair<TKey, TValue>>();
         dictionary = new Dictionary<TKey, TValue>(comparer);
         this.comparer = comparer;
     }
@@ -199,7 +200,7 @@ internal sealed class OrderedDictionary<TKey, TValue> : IOrderedDictionary<TKey,
     internal void OnDeserializedMethod(StreamingContext context)
     {
         // Reconstruct the dictionary from the serialized list
-        dictionary = [];
+        dictionary = new Dictionary<TKey, TValue>();
         foreach (var kvp in list) dictionary[kvp.Key] = kvp.Value;
     }
 
@@ -300,4 +301,6 @@ internal sealed class OrderedDictionary<TKey, TValue> : IOrderedDictionary<TKey,
             return GetEnumerator();
         }
     }
+}
+
 }

--- a/CommandForgeGenerator/YamlDotNet/RepresentationModel/DocumentLoadingState.cs
+++ b/CommandForgeGenerator/YamlDotNet/RepresentationModel/DocumentLoadingState.cs
@@ -23,15 +23,16 @@ using System;
 using System.Collections.Generic;
 using YamlDotNet.Core;
 
-namespace YamlDotNet.RepresentationModel;
+namespace YamlDotNet.RepresentationModel
+{
 
 /// <summary>
 ///     Manages the state of a <see cref="YamlDocument" /> while it is loading.
 /// </summary>
 internal class DocumentLoadingState
 {
-    private readonly Dictionary<AnchorName, YamlNode> anchors = [];
-    private readonly List<YamlNode> nodesWithUnresolvedAliases = [];
+    private readonly Dictionary<AnchorName, YamlNode> anchors = new Dictionary<AnchorName, YamlNode>();
+    private readonly List<YamlNode> nodesWithUnresolvedAliases = new List<YamlNode>();
 
     /// <summary>
     ///     Adds the specified node to the anchor list.
@@ -88,4 +89,6 @@ internal class DocumentLoadingState
     {
         foreach (var node in nodesWithUnresolvedAliases) node.ResolveAliases(this);
     }
+}
+
 }

--- a/CommandForgeGenerator/YamlDotNet/RepresentationModel/EmitterState.cs
+++ b/CommandForgeGenerator/YamlDotNet/RepresentationModel/EmitterState.cs
@@ -33,6 +33,6 @@ namespace YamlDotNet.RepresentationModel
         /// Gets the already emitted anchors.
         /// </summary>
         /// <value>The emitted anchors.</value>
-        public HashSet<AnchorName> EmittedAnchors { get; } = [];
+        public HashSet<AnchorName> EmittedAnchors { get; } = new HashSet<AnchorName>();
     }
 }

--- a/CommandForgeGenerator/YamlDotNet/RepresentationModel/YamlDocument.cs
+++ b/CommandForgeGenerator/YamlDotNet/RepresentationModel/YamlDocument.cs
@@ -90,11 +90,11 @@ namespace YamlDotNet.RepresentationModel
         /// </summary>
         private class AnchorAssigningVisitor : YamlVisitorBase
         {
-            private readonly HashSet<AnchorName> existingAnchors = [];
+            private readonly HashSet<AnchorName> existingAnchors = new HashSet<AnchorName>();
             /// <summary>
             /// Key: Node, Value: IsDuplicate
             /// </summary>
-            private readonly Dictionary<YamlNode, bool> visitedNodes = [];
+            private readonly Dictionary<YamlNode, bool> visitedNodes = new Dictionary<YamlNode, bool>();
 
             public void AssignAnchors(YamlDocument document)
             {

--- a/CommandForgeGenerator/YamlDotNet/RepresentationModel/YamlMappingNode.cs
+++ b/CommandForgeGenerator/YamlDotNet/RepresentationModel/YamlMappingNode.cs
@@ -36,7 +36,7 @@ namespace YamlDotNet.RepresentationModel
     /// </summary>
     public sealed class YamlMappingNode : YamlNode, IEnumerable<KeyValuePair<YamlNode, YamlNode>>, IYamlConvertible
     {
-        private readonly OrderedDictionary<YamlNode, YamlNode> children = [];
+        private readonly OrderedDictionary<YamlNode, YamlNode> children = new OrderedDictionary<YamlNode, YamlNode>();
 
         /// <summary>
         /// Gets the children of the current node.
@@ -196,13 +196,13 @@ namespace YamlDotNet.RepresentationModel
             {
                 if (entry.Key is YamlAliasNode)
                 {
-                    keysToUpdate ??= [];
+                    keysToUpdate ??= new Dictionary<YamlNode, YamlNode>();
                     // TODO: The representation model should be redesigned, because here the anchor could be null but that would be invalid YAML
                     keysToUpdate.Add(entry.Key, state.GetNode(entry.Key.Anchor!, entry.Key.Start, entry.Key.End));
                 }
                 if (entry.Value is YamlAliasNode)
                 {
-                    valuesToUpdate ??= [];
+                    valuesToUpdate ??= new Dictionary<YamlNode, YamlNode>();
                     // TODO: The representation model should be redesigned, because here the anchor could be null but that would be invalid YAML
                     valuesToUpdate.Add(entry.Key, state.GetNode(entry.Value.Anchor!, entry.Value.Start, entry.Value.End));
                 }

--- a/CommandForgeGenerator/YamlDotNet/RepresentationModel/YamlNodeIdentityEqualityComparer.cs
+++ b/CommandForgeGenerator/YamlDotNet/RepresentationModel/YamlNodeIdentityEqualityComparer.cs
@@ -21,7 +21,8 @@
 
 using System.Collections.Generic;
 
-namespace YamlDotNet.RepresentationModel;
+namespace YamlDotNet.RepresentationModel
+{
 
 /// <summary>
 ///     Comparer that is based on identity comparisons.
@@ -43,4 +44,6 @@ public sealed class YamlNodeIdentityEqualityComparer : IEqualityComparer<YamlNod
     }
 
     #endregion
+}
+
 }

--- a/CommandForgeGenerator/YamlDotNet/RepresentationModel/YamlSequenceNode.cs
+++ b/CommandForgeGenerator/YamlDotNet/RepresentationModel/YamlSequenceNode.cs
@@ -36,7 +36,7 @@ namespace YamlDotNet.RepresentationModel
     [DebuggerDisplay("Count = {children.Count}")]
     public sealed class YamlSequenceNode : YamlNode, IEnumerable<YamlNode>, IYamlConvertible
     {
-        private readonly List<YamlNode> children = [];
+        private readonly List<YamlNode> children = new List<YamlNode>();
 
         /// <summary>
         /// Gets the collection of child nodes.

--- a/CommandForgeGenerator/YamlDotNet/RepresentationModel/YamlStream.cs
+++ b/CommandForgeGenerator/YamlDotNet/RepresentationModel/YamlStream.cs
@@ -31,7 +31,7 @@ namespace YamlDotNet.RepresentationModel
     /// </summary>
     public class YamlStream : IEnumerable<YamlDocument>
     {
-        private readonly List<YamlDocument> documents = [];
+        private readonly List<YamlDocument> documents = new List<YamlDocument>();
 
         /// <summary>
         /// Gets the documents inside the stream.

--- a/CommandForgeGenerator/YamlDotNet/Serialization/BufferedDeserialization/TypeDiscriminatingNodeDeserializerOptions.cs
+++ b/CommandForgeGenerator/YamlDotNet/Serialization/BufferedDeserialization/TypeDiscriminatingNodeDeserializerOptions.cs
@@ -30,7 +30,7 @@ namespace YamlDotNet.Serialization.BufferedDeserialization
 {
     public class TypeDiscriminatingNodeDeserializerOptions : ITypeDiscriminatingNodeDeserializerOptions
     {
-        internal readonly List<ITypeDiscriminator> discriminators = [];
+        internal readonly List<ITypeDiscriminator> discriminators = new List<ITypeDiscriminator>();
 
         /// <summary>
         /// Adds an <see cref="ITypeDiscriminator" /> to be checked by the TypeDiscriminatingNodeDeserializer.

--- a/CommandForgeGenerator/YamlDotNet/Serialization/BuilderSkeleton.cs
+++ b/CommandForgeGenerator/YamlDotNet/Serialization/BuilderSkeleton.cs
@@ -58,7 +58,7 @@ namespace YamlDotNet.Serialization
                 { typeof(SystemTypeConverter), _ => new SystemTypeConverter() }
             };
 
-            typeInspectorFactories = [];
+            typeInspectorFactories = new List<Func<ITypeInspector, ITypeInspector>>();
             this.typeResolver = typeResolver ?? throw new ArgumentNullException(nameof(typeResolver));
             settings = new Settings();
         }

--- a/CommandForgeGenerator/YamlDotNet/Serialization/DeserializerBuilder.cs
+++ b/CommandForgeGenerator/YamlDotNet/Serialization/DeserializerBuilder.cs
@@ -71,7 +71,7 @@ namespace YamlDotNet.Serialization
         public DeserializerBuilder()
             : base(new StaticTypeResolver())
         {
-            typeMappings = [];
+            typeMappings = new Dictionary<Type, INodeDeserializer>();
             objectFactory = new Lazy<IObjectFactory>(() => new DefaultObjectFactory(typeMappings, settings), true);
 
             tagMappings = new Dictionary<TagName, Type>

--- a/CommandForgeGenerator/YamlDotNet/Serialization/ITypeInspector.cs
+++ b/CommandForgeGenerator/YamlDotNet/Serialization/ITypeInspector.cs
@@ -22,7 +22,8 @@
 using System;
 using System.Collections.Generic;
 
-namespace YamlDotNet.Serialization;
+namespace YamlDotNet.Serialization
+{
 
 /// <summary>
 ///     Provides access to the properties of a type.
@@ -71,4 +72,6 @@ public interface ITypeInspector
     /// <param name="enumValue"></param>
     /// <returns></returns>
     string GetEnumValue(object enumValue);
+}
+
 }

--- a/CommandForgeGenerator/YamlDotNet/Serialization/LazyComponentRegistrationList.cs
+++ b/CommandForgeGenerator/YamlDotNet/Serialization/LazyComponentRegistrationList.cs
@@ -28,7 +28,7 @@ namespace YamlDotNet.Serialization
 {
     internal sealed class LazyComponentRegistrationList<TArgument, TComponent> : IEnumerable<Func<TArgument, TComponent>>
     {
-        private readonly List<LazyComponentRegistration> entries = [];
+        private readonly List<LazyComponentRegistration> entries = new List<LazyComponentRegistration>();
 
         public LazyComponentRegistrationList<TArgument, TComponent> Clone()
         {

--- a/CommandForgeGenerator/YamlDotNet/Serialization/ObjectGraphVisitors/AnchorAssigner.cs
+++ b/CommandForgeGenerator/YamlDotNet/Serialization/ObjectGraphVisitors/AnchorAssigner.cs
@@ -33,7 +33,7 @@ namespace YamlDotNet.Serialization.ObjectGraphVisitors
             public AnchorName Anchor;
         }
 
-        private readonly Dictionary<object, AnchorAssignment> assignments = [];
+        private readonly Dictionary<object, AnchorAssignment> assignments = new Dictionary<object, AnchorAssignment>();
         private uint nextId;
 
         public AnchorAssigner(IEnumerable<IYamlTypeConverter> typeConverters)

--- a/CommandForgeGenerator/YamlDotNet/Serialization/ObjectGraphVisitors/AnchorAssigningObjectGraphVisitor.cs
+++ b/CommandForgeGenerator/YamlDotNet/Serialization/ObjectGraphVisitors/AnchorAssigningObjectGraphVisitor.cs
@@ -29,7 +29,7 @@ namespace YamlDotNet.Serialization.ObjectGraphVisitors
     {
         private readonly IEventEmitter eventEmitter;
         private readonly IAliasProvider aliasProvider;
-        private readonly HashSet<AnchorName> emittedAliases = [];
+        private readonly HashSet<AnchorName> emittedAliases = new HashSet<AnchorName>();
 
         public AnchorAssigningObjectGraphVisitor(IObjectGraphVisitor<IEmitter> nextVisitor, IEventEmitter eventEmitter, IAliasProvider aliasProvider)
             : base(nextVisitor)

--- a/CommandForgeGenerator/YamlDotNet/Serialization/SerializerBuilder.cs
+++ b/CommandForgeGenerator/YamlDotNet/Serialization/SerializerBuilder.cs
@@ -55,7 +55,7 @@ namespace YamlDotNet.Serialization
         private readonly LazyComponentRegistrationList<IEnumerable<IYamlTypeConverter>, IObjectGraphVisitor<Nothing>> preProcessingPhaseObjectGraphVisitorFactories;
         private readonly LazyComponentRegistrationList<EmissionPhaseObjectGraphVisitorArgs, IObjectGraphVisitor<IEmitter>> emissionPhaseObjectGraphVisitorFactories;
         private readonly LazyComponentRegistrationList<IEventEmitter, IEventEmitter> eventEmitterFactories;
-        private readonly Dictionary<Type, TagName> tagMappings = [];
+        private readonly Dictionary<Type, TagName> tagMappings = new Dictionary<Type, TagName>();
         private readonly IObjectFactory objectFactory;
         private int maximumRecursion = 50;
         private EmitterSettings emitterSettings = EmitterSettings.Default;

--- a/CommandForgeGenerator/YamlDotNet/Serialization/StaticBuilderSkeleton.cs
+++ b/CommandForgeGenerator/YamlDotNet/Serialization/StaticBuilderSkeleton.cs
@@ -50,7 +50,7 @@ namespace YamlDotNet.Serialization
                 { typeof(GuidConverter), _ => new GuidConverter(false) },
             };
 
-            typeInspectorFactories = [];
+            typeInspectorFactories = new List<Func<ITypeInspector, ITypeInspector>>();
             this.typeResolver = typeResolver ?? throw new ArgumentNullException(nameof(typeResolver));
             settings = new Settings();
         }

--- a/CommandForgeGenerator/YamlDotNet/Serialization/StaticDeserializerBuilder.cs
+++ b/CommandForgeGenerator/YamlDotNet/Serialization/StaticDeserializerBuilder.cs
@@ -70,7 +70,7 @@ namespace YamlDotNet.Serialization
         {
             this.context = context;
             factory = context.GetFactory();
-            typeMappings = [];
+            typeMappings = new Dictionary<Type, INodeDeserializer>();
 
             tagMappings = new Dictionary<TagName, Type>
             {

--- a/CommandForgeGenerator/YamlDotNet/Serialization/StaticSerializerBuilder.cs
+++ b/CommandForgeGenerator/YamlDotNet/Serialization/StaticSerializerBuilder.cs
@@ -52,7 +52,7 @@ namespace YamlDotNet.Serialization
         private readonly LazyComponentRegistrationList<IEnumerable<IYamlTypeConverter>, IObjectGraphVisitor<Nothing>> preProcessingPhaseObjectGraphVisitorFactories;
         private readonly LazyComponentRegistrationList<EmissionPhaseObjectGraphVisitorArgs, IObjectGraphVisitor<IEmitter>> emissionPhaseObjectGraphVisitorFactories;
         private readonly LazyComponentRegistrationList<IEventEmitter, IEventEmitter> eventEmitterFactories;
-        private readonly Dictionary<Type, TagName> tagMappings = [];
+        private readonly Dictionary<Type, TagName> tagMappings = new Dictionary<Type, TagName>();
         private int maximumRecursion = 50;
         private EmitterSettings emitterSettings = EmitterSettings.Default;
         private DefaultValuesHandling defaultValuesHandlingConfiguration = DefaultValuesHandling.Preserve;

--- a/CommandForgeGenerator/YamlDotNet/Serialization/StreamFragment.cs
+++ b/CommandForgeGenerator/YamlDotNet/Serialization/StreamFragment.cs
@@ -32,7 +32,7 @@ namespace YamlDotNet.Serialization
     /// </summary>
     public sealed class StreamFragment : IYamlConvertible
     {
-        private readonly List<ParsingEvent> events = [];
+        private readonly List<ParsingEvent> events = new List<ParsingEvent>();
 
         /// <summary>
         /// Gets or sets the events.

--- a/CommandForgeGenerator/YamlDotNet/Serialization/TagMappings.cs
+++ b/CommandForgeGenerator/YamlDotNet/Serialization/TagMappings.cs
@@ -36,7 +36,7 @@ namespace YamlDotNet.Serialization
         /// </summary>
         public TagMappings()
         {
-            mappings = [];
+            mappings = new Dictionary<string, Type>();
         }
 
         /// <summary>

--- a/CommandForgeGenerator/YamlDotNet/Serialization/TypeInspectors/TypeInspectorSkeleton.cs
+++ b/CommandForgeGenerator/YamlDotNet/Serialization/TypeInspectors/TypeInspectorSkeleton.cs
@@ -24,7 +24,8 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.Serialization;
 
-namespace YamlDotNet.Serialization.TypeInspectors;
+namespace YamlDotNet.Serialization.TypeInspectors
+{
 
 public abstract class TypeInspectorSkeleton : ITypeInspector
 {
@@ -62,4 +63,6 @@ public abstract class TypeInspectorSkeleton : ITypeInspector
 
         return property;
     }
+}
+
 }

--- a/CommandForgeGenerator/YamlDotNet/Serialization/Utilities/ObjectAnchorCollection.cs
+++ b/CommandForgeGenerator/YamlDotNet/Serialization/Utilities/ObjectAnchorCollection.cs
@@ -22,12 +22,13 @@
 using System.Collections.Generic;
 using YamlDotNet.Core;
 
-namespace YamlDotNet.Serialization.Utilities;
+namespace YamlDotNet.Serialization.Utilities
+{
 
 internal sealed class ObjectAnchorCollection
 {
-    private readonly Dictionary<object, string> anchorsByObject = [];
-    private readonly Dictionary<string, object> objectsByAnchor = [];
+    private readonly Dictionary<object, string> anchorsByObject = new Dictionary<object, string>();
+    private readonly Dictionary<string, object> objectsByAnchor = new Dictionary<string, object>();
 
     /// <summary>
     ///     Gets the <see cref="object" /> with the specified anchor.
@@ -64,4 +65,6 @@ internal sealed class ObjectAnchorCollection
     {
         return anchorsByObject.TryGetValue(@object, out anchor);
     }
+}
+
 }

--- a/CommandForgeGenerator/YamlDotNet/Serialization/Utilities/SerializerState.cs
+++ b/CommandForgeGenerator/YamlDotNet/Serialization/Utilities/SerializerState.cs
@@ -31,7 +31,7 @@ namespace YamlDotNet.Serialization.Utilities
     /// </summary>
     public sealed class SerializerState : IDisposable
     {
-        private readonly Dictionary<Type, object> items = [];
+        private readonly Dictionary<Type, object> items = new Dictionary<Type, object>();
 
         public T Get<T>()
             where T : class, new()

--- a/CommandForgeGenerator/YamlDotNet/Serialization/Utilities/TypeConverter.cs
+++ b/CommandForgeGenerator/YamlDotNet/Serialization/Utilities/TypeConverter.cs
@@ -30,7 +30,8 @@ using System.Linq;
 using System.Reflection;
 using YamlDotNet.Helpers;
 
-namespace YamlDotNet.Serialization.Utilities;
+namespace YamlDotNet.Serialization.Utilities
+{
 
 /// <summary>
 ///     Performs type conversions using every standard provided by the .NET library.
@@ -209,4 +210,6 @@ public static class TypeConverter
 
         if (!alreadyRegistered) TypeDescriptor.AddAttributes(typeof(TConvertible), new TypeConverterAttribute(typeof(TConverter)));
     }
+}
+
 }

--- a/CommandForgeGenerator/YamlDotNet/Serialization/Utilities/TypeConverterCache.cs
+++ b/CommandForgeGenerator/YamlDotNet/Serialization/Utilities/TypeConverterCache.cs
@@ -25,7 +25,8 @@ using System.Collections.Generic;
 using System.Linq;
 using YamlDotNet.Helpers;
 
-namespace YamlDotNet.Serialization.Utilities;
+namespace YamlDotNet.Serialization.Utilities
+{
 
 /// <summary>
 ///     A cache / map for <see cref="IYamlTypeConverter" /> instances.
@@ -35,7 +36,7 @@ internal sealed class TypeConverterCache
     private readonly ConcurrentDictionary<Type, (bool HasMatch, IYamlTypeConverter? TypeConverter)> cache = new();
     private readonly IYamlTypeConverter[] typeConverters;
 
-    public TypeConverterCache(IEnumerable<IYamlTypeConverter>? typeConverters) : this(typeConverters?.ToArray() ?? [])
+    public TypeConverterCache(IEnumerable<IYamlTypeConverter>? typeConverters) : this(typeConverters?.ToArray() ?? Array.Empty<IYamlTypeConverter>())
     {
     }
 
@@ -92,4 +93,6 @@ internal sealed class TypeConverterCache
 
         return (false, null);
     }
+}
+
 }

--- a/CommandForgeGenerator/YamlDotNet/Serialization/YamlAttributeOverrides.cs
+++ b/CommandForgeGenerator/YamlDotNet/Serialization/YamlAttributeOverrides.cs
@@ -33,7 +33,7 @@ namespace YamlDotNet.Serialization
     /// </summary>
     public sealed partial class YamlAttributeOverrides
     {
-        private readonly Dictionary<AttributeKey, List<AttributeMapping>> overrides = [];
+        private readonly Dictionary<AttributeKey, List<AttributeMapping>> overrides = new Dictionary<AttributeKey, List<AttributeMapping>>();
 
         public T GetAttribute<T>(Type type, string member) where T : Attribute
         {
@@ -71,7 +71,7 @@ namespace YamlDotNet.Serialization
             var attributeKey = new AttributeKey(attribute.GetType(), member);
             if (!overrides.TryGetValue(attributeKey, out var mappings))
             {
-                mappings = [];
+                mappings = new List<AttributeMapping>();
                 overrides.Add(attributeKey, mappings);
             }
             else if (mappings.Contains(mapping))


### PR DESCRIPTION
## Summary
- target C# 9 by setting `<LangVersion>9.0</LangVersion>` in all csproj files
- replace file‑scoped namespaces with block scopes
- remove C# 10/12 syntax like `record struct` and collection expressions

## Testing
- ❌ `dotnet test --no-build` (failed to run: `dotnet` not found)
